### PR TITLE
Fix syntax error in flipFront function

### DIFF
--- a/CardLearner/CardLearner/wwwroot/js/scripts.js
+++ b/CardLearner/CardLearner/wwwroot/js/scripts.js
@@ -6,7 +6,7 @@
 function flipFront(button) {
     const cardContainer = button.closest('.card-front');
     cardContainer.classList.add('flipped');
-})
+}
 
 function flipBack(event, button) {
     event.stopPropagation();


### PR DESCRIPTION
## Summary
- Fix `flipFront` JS helper to properly close its block with `}`

## Testing
- `node --check CardLearner/CardLearner/wwwroot/js/scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5ba6e23948320adcff94351c81ed7