### PR TITLE
Use path segments in QuestionUpdater

### DIFF
--- a/CardLearner/CardLearner.QuestionUpdater/Program.cs
+++ b/CardLearner/CardLearner.QuestionUpdater/Program.cs
@@ -14,7 +14,7 @@ namespace CardLearner.QuestionUpdater
         static async Task Main(string[] args)
         {
             string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-            string projectDirectory = Path.GetFullPath(Path.Combine(baseDirectory, @"..\..\.."));
+            string projectDirectory = Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", ".."));
             string urlsFilePath = Path.Combine(projectDirectory, "urls.txt");
             string questionsDirectory = Path.Combine(projectDirectory, "questions");
             string jsonFilePath = Path.Combine(questionsDirectory, "az-204.json");


### PR DESCRIPTION
## Summary
- use Path.Combine with individual segments to build project path

## Testing
- `dotnet test CardLearner/CardLearner.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ba7627cc8320a659d689416022af