### PR TITLE
Add tests for QuestionExists in QuestionUpdater

### DIFF
--- a/CardLearner/CardLearner.QuestionUpdater.Tests/CardLearner.QuestionUpdater.Tests.csproj
+++ b/CardLearner/CardLearner.QuestionUpdater.Tests/CardLearner.QuestionUpdater.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CardLearner.QuestionUpdater\CardLearner.QuestionUpdater.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CardLearner/CardLearner.QuestionUpdater.Tests/UnitTests/QuestionExistsTests.cs
+++ b/CardLearner/CardLearner.QuestionUpdater.Tests/UnitTests/QuestionExistsTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using CardLearner.Models;
+using CardLearner.QuestionUpdater;
+using Xunit;
+
+namespace CardLearner.QuestionUpdater.Tests.UnitTests
+{
+    public class QuestionExistsTests
+    {
+        private static (bool exists, int questionNumber, int topicNumber) InvokeQuestionExists(List<Question> questions, string url)
+        {
+            var assembly = typeof(WebPageParser).Assembly;
+            var programType = assembly.GetType("CardLearner.QuestionUpdater.Program", true);
+            var method = programType.GetMethod("QuestionExists", BindingFlags.NonPublic | BindingFlags.Static);
+            return ((bool, int, int))method.Invoke(null, new object[] { questions, url });
+        }
+
+        [Fact]
+        public void ReturnsTrueForExistingQuestion()
+        {
+            var questions = new List<Question>
+            {
+                new Question { Number = 1, Topic = 2 }
+            };
+            var url = "https://example.com/topic-2-question-1/";
+            var (exists, questionNumber, topicNumber) = InvokeQuestionExists(questions, url);
+
+            Assert.True(exists);
+            Assert.Equal(1, questionNumber);
+            Assert.Equal(2, topicNumber);
+        }
+
+        [Theory]
+        [InlineData("https://example.com/topic-2-question-99/")]
+        [InlineData("https://example.com/not-a-valid-url")]
+        [InlineData("")]
+        public void ReturnsFalseForNonExistingOrInvalidUrl(string url)
+        {
+            var questions = new List<Question>();
+            var (exists, questionNumber, topicNumber) = InvokeQuestionExists(questions, url);
+
+            Assert.False(exists);
+            Assert.Equal(0, questionNumber);
+            Assert.Equal(0, topicNumber);
+        }
+
+        [Fact]
+        public void DoesNotThrowOnBadFormat()
+        {
+            var questions = new List<Question>();
+            var url = "bad-format";
+
+            var exception = Record.Exception(() => InvokeQuestionExists(questions, url));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/CardLearner/CardLearner.sln
+++ b/CardLearner/CardLearner.sln
@@ -12,6 +12,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CardLearner.Models", "CardL
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CardLearner.QuestionUpdater", "CardLearner.QuestionUpdater\CardLearner.QuestionUpdater.csproj", "{57717B24-6328-4370-9885-81D8BDA63EA3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CardLearner.QuestionUpdater.Tests", "CardLearner.QuestionUpdater.Tests\CardLearner.QuestionUpdater.Tests.csproj", "{FD314F8E-2D72-409B-B045-283A2D8B6A5C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,6 +32,10 @@ Global
 		{57717B24-6328-4370-9885-81D8BDA63EA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{57717B24-6328-4370-9885-81D8BDA63EA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{57717B24-6328-4370-9885-81D8BDA63EA3}.Release|Any CPU.Build.0 = Release|Any CPU
+                {FD314F8E-2D72-409B-B045-283A2D8B6A5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {FD314F8E-2D72-409B-B045-283A2D8B6A5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {FD314F8E-2D72-409B-B045-283A2D8B6A5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {FD314F8E-2D72-409B-B045-283A2D8B6A5C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add xUnit test project for `QuestionExists` logic
- cover existing, invalid, and malformed URL scenarios

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ba89343483209b9a6a75c7f8b006