### PR TITLE
Add responsive layout to quiz and baseline viewport test

### DIFF
--- a/CardLearner/CardLearner/Pages/Quiz.cshtml
+++ b/CardLearner/CardLearner/Pages/Quiz.cshtml
@@ -21,7 +21,10 @@
                 <button type="button" class="answer-option" data-question-id="@question.Id" data-correct-answer="@question.CorrectAnswer">@option</button>
             }
         </div>
-        <button type="button" class="edit-answer">Edit</button>
+        <div class="action-buttons">
+            <button type="button" class="edit-answer">Edit</button>
+            <button type="button" class="toggle-explanation">Show Explanation</button>
+        </div>
         <div class="edit-answer-form" style="display:none;">
             <label for="correct-answer-@question.Id">Correct Answer:</label>
             <select id="correct-answer-@question.Id" class="correct-answer-select" data-current-answer="@question.CorrectAnswer" data-question-id="@question.Id">
@@ -37,7 +40,6 @@
                 <button type="button" class="save-explanation" data-question-id="@question.Id">Save Explanation</button>
             </div>
         </div>
-        <button type="button" class="toggle-explanation">Show Explanation</button>
         <div class="explanation" style="display:none;">
             <p>@question.Explanation</p>
             @if (!string.IsNullOrEmpty(question.ExplanationImageUrl))

--- a/CardLearner/CardLearner/Pages/Shared/_Layout.cshtml
+++ b/CardLearner/CardLearner/Pages/Shared/_Layout.cshtml
@@ -12,8 +12,11 @@
 <body>
     <header class="bg-light shadow-sm">
         <nav class="navbar navbar-expand-sm navbar-light bg-light container">
-            <div class="navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav ml-auto">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
                         <a class="nav-link" asp-area="" asp-page="/Quiz">Quiz</a>
                     </li>

--- a/CardLearner/CardLearner/wwwroot/css/quiz.css
+++ b/CardLearner/CardLearner/wwwroot/css/quiz.css
@@ -5,6 +5,8 @@
     border-radius: 10px;
     background-color: #ffffff;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
 }
 
 .question-image, .explanation-image {
@@ -57,6 +59,7 @@
     display: flex;
     gap: 10px;
     margin-top: 10px;
+    flex-wrap: wrap;
 }
 
 .toggle-explanation,
@@ -117,4 +120,17 @@
 
 .edit-explanation-form {
     display: none;
+}
+
+/* Responsive adjustments */
+@media (max-width: 576px) {
+    .options-grid {
+        grid-template-columns: 1fr;
+    }
+    .action-buttons {
+        flex-direction: column;
+    }
+    .action-buttons button {
+        width: 100%;
+    }
 }

--- a/CardLearner/CardLearner/wwwroot/js/quiz.js
+++ b/CardLearner/CardLearner/wwwroot/js/quiz.js
@@ -2,7 +2,7 @@
     // Handle explanation toggle
     document.querySelectorAll(".toggle-explanation").forEach(function (button) {
         button.addEventListener("click", function () {
-            var explanation = this.nextElementSibling;
+            var explanation = this.closest(".question-block").querySelector(".explanation");
             if (explanation.style.display === "none" || explanation.style.display === "") {
                 explanation.style.display = "block";
                 this.textContent = "Hide Explanation";
@@ -39,7 +39,7 @@
     // Handle edit answer form toggle
     document.querySelectorAll(".edit-answer").forEach(function (button) {
         button.addEventListener("click", function () {
-            var form = this.nextElementSibling;
+            var form = this.closest(".question-block").querySelector(".edit-answer-form");
             if (form.style.display === "none" || form.style.display === "") {
                 form.style.display = "block";
             } else {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cardlearner",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+    "scripts": {
+      "test": "node tests/responsive.test.js"
+    },
+    "devDependencies": {
+      "puppeteer": "^22.0.0"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "type": "commonjs"
+  }

--- a/tests/responsive.test.js
+++ b/tests/responsive.test.js
@@ -1,0 +1,29 @@
+const { spawn } = require('child_process');
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const server = spawn('dotnet', ['run', '--project', 'CardLearner/CardLearner', '--urls', 'http://localhost:5000'], { stdio: 'inherit' });
+  // wait for server to start
+  await new Promise(resolve => setTimeout(resolve, 5000));
+
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.goto('http://localhost:5000/quiz');
+
+  await page.setViewport({ width: 1024, height: 800 });
+  const columnsDesktop = await page.evaluate(() => getComputedStyle(document.querySelector('.options-grid')).gridTemplateColumns.split(' ').length);
+
+  await page.setViewport({ width: 500, height: 800 });
+  const columnsMobile = await page.evaluate(() => getComputedStyle(document.querySelector('.options-grid')).gridTemplateColumns.split(' ').length);
+
+  console.log('columnsDesktop', columnsDesktop, 'columnsMobile', columnsMobile);
+
+  await browser.close();
+  server.kill();
+
+  if (columnsDesktop <= columnsMobile) {
+    console.error('Responsive grid test failed');
+    process.exit(1);
+  }
+  console.log('Responsive grid test passed');
+})();


### PR DESCRIPTION
## Summary
- improve quiz layout with flexbox, grid, and mobile media queries
- make site navbar collapsible for small screens
- add Puppeteer test to check grid columns at different widths

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bd77ce548320b066b754c375a462