### PR TITLE
Add quiz result tracking and submission endpoint

### DIFF
--- a/CardLearner/CardLearner/Controllers/QuizController.cs
+++ b/CardLearner/CardLearner/Controllers/QuizController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CardLearner.Controllers
+{
+    [Route("api/quiz")]
+    [ApiController]
+    public class QuizController : ControllerBase
+    {
+        [HttpPost("submit")]
+        public IActionResult Submit([FromBody] List<QuizResult> results)
+        {
+            if (results == null || results.Count == 0)
+            {
+                return BadRequest("No results provided.");
+            }
+
+            var summary = new
+            {
+                total = results.Count,
+                correct = results.Count(r => r.IsCorrect)
+            };
+
+            return Ok(summary);
+        }
+    }
+
+    public class QuizResult
+    {
+        public int QuestionId { get; set; }
+        public string SelectedAnswer { get; set; }
+        public bool IsCorrect { get; set; }
+    }
+}

--- a/CardLearner/CardLearner/Pages/Quiz.cshtml
+++ b/CardLearner/CardLearner/Pages/Quiz.cshtml
@@ -48,6 +48,11 @@
     </div>
 }
 
+<div id="quiz-results" style="display:none;" class="quiz-results">
+    <h2>Results</h2>
+    <p id="quiz-score"></p>
+</div>
+
 @section Styles {
     <link rel="stylesheet" href="~/css/quiz.css" asp-append-version="true" />
 }

--- a/CardLearner/CardLearner/wwwroot/js/quiz.js
+++ b/CardLearner/CardLearner/wwwroot/js/quiz.js
@@ -1,4 +1,7 @@
 ﻿document.addEventListener("DOMContentLoaded", function () {
+    var quizResults = [];
+    var totalQuestions = document.querySelectorAll('.question-block').length;
+
     // Handle explanation toggle
     document.querySelectorAll(".toggle-explanation").forEach(function (button) {
         button.addEventListener("click", function () {
@@ -21,17 +24,34 @@
             var selectedAnswer = this.textContent;
             var options = document.querySelectorAll("#question-" + questionId + " .answer-option");
 
-            if (selectedAnswer === correctAnswer) {
-                options.forEach(function (opt) {
-                    opt.disabled = true;
-                    if (opt.textContent === correctAnswer) {
-                        opt.style.backgroundColor = "green";
-                        opt.style.color = "white";
-                    }
-                });
-            } else {
+            if (quizResults.some(r => r.questionId === parseInt(questionId))) {
+                return;
+            }
+
+            var isCorrect = selectedAnswer === correctAnswer;
+
+            options.forEach(function (opt) {
+                opt.disabled = true;
+                if (opt.textContent === correctAnswer) {
+                    opt.style.backgroundColor = "green";
+                    opt.style.color = "white";
+                }
+            });
+
+            if (!isCorrect) {
                 this.style.backgroundColor = "red";
                 this.style.color = "white";
+            }
+
+            quizResults.push({
+                questionId: parseInt(questionId),
+                selectedAnswer: selectedAnswer,
+                isCorrect: isCorrect
+            });
+
+            if (quizResults.length === totalQuestions) {
+                submitQuizResults(quizResults);
+                showQuizResults(quizResults, totalQuestions);
             }
         });
     });
@@ -106,6 +126,39 @@
         });
     });
 });
+
+function submitQuizResults(results) {
+    fetch('/api/quiz/submit', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(results)
+    })
+        .then(response => response.json())
+        .then(data => {
+            console.log('Quiz results submitted:', data);
+        })
+        .catch((error) => {
+            console.error('Error submitting quiz results:', error);
+        });
+}
+
+function showQuizResults(results, total) {
+    var correctCount = results.filter(r => r.isCorrect).length;
+    var resultsDiv = document.getElementById('quiz-results');
+    var scoreParagraph = document.getElementById('quiz-score');
+
+    if (scoreParagraph) {
+        scoreParagraph.textContent = `You answered ${correctCount} out of ${total} questions correctly.`;
+    } else if (resultsDiv) {
+        resultsDiv.textContent = `You answered ${correctCount} out of ${total} questions correctly.`;
+    }
+
+    if (resultsDiv) {
+        resultsDiv.style.display = 'block';
+    }
+}
 
 // Example function to send AJAX request to update correct answer on the server side
 function updateCorrectAnswer(questionId, newCorrectAnswer) {


### PR DESCRIPTION
## Summary
- Track selected answers in quiz script and submit aggregated results to server
- Display results summary on quiz page after completion
- Provide `/api/quiz/submit` API endpoint to receive quiz results

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bdda74d88320bd3ddafab25b0cf5