### PR TITLE
Add user authentication and progress tracking

### DIFF
--- a/CardLearner/CardLearner.Models/User.cs
+++ b/CardLearner/CardLearner.Models/User.cs
@@ -1,0 +1,13 @@
+namespace CardLearner.Models;
+
+public class User
+{
+    public int Id { get; set; }
+
+    public string UserName { get; set; } = string.Empty;
+
+    public string PasswordHash { get; set; } = string.Empty;
+
+    public ICollection<UserProgress> Progresses { get; set; } = new List<UserProgress>();
+}
+

--- a/CardLearner/CardLearner.Models/UserProgress.cs
+++ b/CardLearner/CardLearner.Models/UserProgress.cs
@@ -1,0 +1,17 @@
+namespace CardLearner.Models;
+
+public class UserProgress
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public string QuizName { get; set; } = string.Empty;
+
+    public int CurrentQuestionIndex { get; set; }
+
+    public int Score { get; set; }
+
+    public User? User { get; set; }
+}
+

--- a/CardLearner/CardLearner/CardLearner.csproj
+++ b/CardLearner/CardLearner/CardLearner.csproj
@@ -18,6 +18,11 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/CardLearner/CardLearner/Controllers/AccountController.cs
+++ b/CardLearner/CardLearner/Controllers/AccountController.cs
@@ -1,0 +1,77 @@
+using CardLearner.Data;
+using CardLearner.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CardLearner.Controllers;
+
+[Route("[controller]")]
+public class AccountController : Controller
+{
+    private readonly ApplicationDbContext _context;
+
+    public AccountController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromForm] string username, [FromForm] string password)
+    {
+        var user = new User
+        {
+            UserName = username,
+            PasswordHash = Hash(password)
+        };
+
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync();
+
+        await SignInAsync(user);
+
+        return Ok();
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromForm] string username, [FromForm] string password)
+    {
+        var hash = Hash(password);
+        var user = await _context.Users
+            .FirstOrDefaultAsync(u => u.UserName == username && u.PasswordHash == hash);
+
+        if (user == null)
+        {
+            return Unauthorized();
+        }
+
+        await SignInAsync(user);
+
+        return Ok();
+    }
+
+    private async Task SignInAsync(User user)
+    {
+        var claims = new List<Claim>
+        {
+            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+            new Claim(ClaimTypes.Name, user.UserName)
+        };
+
+        var claimsIdentity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+        await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(claimsIdentity));
+    }
+
+    private static string Hash(string input)
+    {
+        using var sha = SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToBase64String(hash);
+    }
+}
+

--- a/CardLearner/CardLearner/Data/ApplicationDbContext.cs
+++ b/CardLearner/CardLearner/Data/ApplicationDbContext.cs
@@ -1,0 +1,16 @@
+using CardLearner.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CardLearner.Data;
+
+public class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<User> Users => Set<User>();
+
+    public DbSet<UserProgress> UserProgresses => Set<UserProgress>();
+}
+

--- a/CardLearner/CardLearner/Pages/Quiz.cshtml.cs
+++ b/CardLearner/CardLearner/Pages/Quiz.cshtml.cs
@@ -5,12 +5,23 @@ using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using CardLearner.Models;
+using CardLearner.Services;
+using System.Security.Claims;
 
 namespace CardLearner.Pages
 {
     public class QuizModel : PageModel
     {
+        private readonly IProgressService _progressService;
+
+        public QuizModel(IProgressService progressService)
+        {
+            _progressService = progressService;
+        }
+
         public List<Question>? Questions { get; set; }
+
+        public UserProgress? Progress { get; set; }
 
         public async Task OnGet()
         {
@@ -20,6 +31,31 @@ namespace CardLearner.Pages
                 var res = await JsonSerializer.DeserializeAsync<List<Question>>(jsonFile);
                 Questions = res ?? new List<Question>();
             }
+
+            if (User.Identity?.IsAuthenticated == true)
+            {
+                var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+                Progress = await _progressService.GetProgressAsync(userId, "az-204");
+            }
+        }
+
+        public async Task<IActionResult> OnPostSaveAsync(int currentIndex, int score)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return Unauthorized();
+            }
+
+            var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+            await _progressService.SaveProgressAsync(new UserProgress
+            {
+                UserId = userId,
+                QuizName = "az-204",
+                CurrentQuestionIndex = currentIndex,
+                Score = score
+            });
+
+            return new JsonResult(new { success = true });
         }
     }
 }

--- a/CardLearner/CardLearner/Program.cs
+++ b/CardLearner/CardLearner/Program.cs
@@ -4,11 +4,26 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using CardLearner.Models;
+using CardLearner.Data;
+using CardLearner.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authentication.Cookies;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
 builder.Services.AddControllers();
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(options =>
+    {
+        options.LoginPath = "/account/login";
+    });
+
+builder.Services.AddScoped<IProgressService, ProgressService>();
 
 builder.Services.AddSwaggerGen(c =>
 {
@@ -21,6 +36,12 @@ builder.Services.AddSwaggerGen(c =>
 
 var app = builder.Build();
 
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    db.Database.EnsureCreated();
+}
+
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error");
@@ -32,6 +53,7 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.UseSwagger();

--- a/CardLearner/CardLearner/Services/IProgressService.cs
+++ b/CardLearner/CardLearner/Services/IProgressService.cs
@@ -1,0 +1,11 @@
+using CardLearner.Models;
+
+namespace CardLearner.Services;
+
+public interface IProgressService
+{
+    Task<UserProgress?> GetProgressAsync(int userId, string quizName);
+
+    Task SaveProgressAsync(UserProgress progress);
+}
+

--- a/CardLearner/CardLearner/Services/ProgressService.cs
+++ b/CardLearner/CardLearner/Services/ProgressService.cs
@@ -1,0 +1,40 @@
+using CardLearner.Data;
+using CardLearner.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CardLearner.Services;
+
+public class ProgressService : IProgressService
+{
+    private readonly ApplicationDbContext _context;
+
+    public ProgressService(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<UserProgress?> GetProgressAsync(int userId, string quizName)
+    {
+        return await _context.UserProgresses
+            .FirstOrDefaultAsync(p => p.UserId == userId && p.QuizName == quizName);
+    }
+
+    public async Task SaveProgressAsync(UserProgress progress)
+    {
+        var existing = await _context.UserProgresses
+            .FirstOrDefaultAsync(p => p.UserId == progress.UserId && p.QuizName == progress.QuizName);
+
+        if (existing == null)
+        {
+            _context.UserProgresses.Add(progress);
+        }
+        else
+        {
+            existing.CurrentQuestionIndex = progress.CurrentQuestionIndex;
+            existing.Score = progress.Score;
+        }
+
+        await _context.SaveChangesAsync();
+    }
+}
+

--- a/CardLearner/CardLearner/appsettings.json
+++ b/CardLearner/CardLearner/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=cardlearner.db"
+  }
 }


### PR DESCRIPTION
## Summary
- integrate EF Core with SQLite and add User/UserProgress models
- set up cookie authentication and create AccountController for register and login
- persist quiz progress via IProgressService in Quiz page

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bdf4aae88320b91cc7017138287e